### PR TITLE
Use `env bash` instead of `bash`

### DIFF
--- a/magito
+++ b/magito
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MAGITO_HOME=$(dirname "$(readlink "$0")")
 REPO=$(basename "`pwd`")


### PR DESCRIPTION
Using `/usr/bin/env bash` makes it use `bash` from the `$PATH`, and
it is more portable than hardcoding the path to `sh`; when you're
using obscure OS's like NixOS.

MacOS also has this, so it should keep working there.